### PR TITLE
Update dependency url to swiftlang org

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .executable(name: "swift-evolution-metadata-extractor", targets: ["swift-evolution-metadata-extractor"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-markdown", from: "0.3.0"),
+        .package(url: "https://github.com/swiftlang/swift-markdown", from: "0.3.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
     ],
     targets: [


### PR DESCRIPTION
Update dependency GitHub url for swift-markdown which has moved to the swiftlang organization.