### PR TITLE
Skip subdirectories under `proposals/` in the network extraction job.

### DIFF
--- a/Sources/EvolutionMetadataExtraction/Utilities/Networking.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/Networking.swift
@@ -54,7 +54,7 @@ struct GitHubContentItem: Codable {
     var url: String
     var html_url: String
     var git_url: String
-    var download_url: String
+    var download_url: String?
     var type: String
     var _links: LinkContainer
     
@@ -63,9 +63,12 @@ struct GitHubContentItem: Codable {
         var git: String
         var html: String
     }
-    
-    func proposalSpec(sortIndex: Int) ->  ProposalSpec {
-        ProposalSpec(url: URL(string: download_url)!, sha: sha, sortIndex: sortIndex)
+
+    /// Returns `nil` if this content item corresponds to a
+    /// subdirectory instead of a direct proposal document.
+    func proposalSpec(sortIndex: Int) ->  ProposalSpec? {
+        guard let download_url else { return nil }
+        return ProposalSpec(url: URL(string: download_url)!, sha: sha, sortIndex: sortIndex)
     }
 }
 


### PR DESCRIPTION
The swift-evolution repository now has a `testing/` subdirectory of `proposals/`, which is where proposals run by the Swift Testing workgroup will be added once they start running reviews through the Swift Evolution process (currently the directory only contains historical proposals). Adding this subdirectory broke the network extraction job, because the `download_url` for a subdirectory is `null`, so the JSON decoding into `GitHubContentItem` failed. To fix this, I made `download_url` an optional string, and simply skip subdirectories in `makeNetworkExtractionJob`.

Eventually, the network extraction job should flatten the list of proposals.