### PR TITLE
Ensure generated metadata always uses current tool version

### DIFF
--- a/Sources/EvolutionMetadataExtraction/Extractors/EvolutionMetadataExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/EvolutionMetadataExtractor.swift
@@ -58,7 +58,7 @@ struct EvolutionMetadataExtractor {
             implementationVersions: implementationVersions,
             proposals: combinedProposals,
             commit: extractionJob.jobMetadata.commit ?? "",
-            toolVersion: extractionJob.jobMetadata.toolVersion
+            toolVersion: ToolVersion.version
         )
     }
     


### PR DESCRIPTION
- Remove unused functionality to create extraction job wth tool version
- Use the ToolVersion.version property value for all generated metadata
- Resolves #65