### PR TITLE
Add `validate` command and validation reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Add new items at the end of the relevant section under **Unreleased**.
 
 ### Additions
 
-*No additions*
+- Add `validate` subcommand to generate validate reports
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,27 @@ When present, the provided token will be included as an authorization header in 
 ## EvolutionMetadataModel Library
 The package vends the `EvolutionMetadataModel` library. The library defines `Codable`, `Equatable`, `Sendable` value types that are suitable for decoding the generated evolution metadata file.
 
+## Validation Reports
+The `validate` command will extract metadata and generate a validation report containing any validation errors or warnings found.  By default the report will be written to standard out.
+
+If errors are found the tool will exit with an error code.
+
+The validate command is intended to be run on pull requests to ensure malformed proposal files are not committed.
+
+### Options
+The validate subcommand has options that work similar to extract command options:
+- Use the `--output-path` option (`-o`) to specify a different output location or filename.
+
+- Use the `--verbose` option (`-v`) for verbose output as the tool runs.
+
+- Use the `--snapshot-path` option to specify a local `evosnapshot` directory as a data source.
+
+- Use trailing `<proposal-files>` argument of paths to proposal files in the Markdown format with the extension `md`.
+
+  Use the `<proposal-files>` argument to validate one or more local proposal files.
+
+The `--snapshot-path` and `<proposal-files>` argument are mutually exclusive.
+
 ## Snapshots for Development and Testing
 Use the `snapshot` subcommand to record snapshots.
 

--- a/Sources/EvolutionMetadataExtraction/CommandLineSupport.swift
+++ b/Sources/EvolutionMetadataExtraction/CommandLineSupport.swift
@@ -27,6 +27,12 @@ public enum ToolVersion {
 
 // MARK: -
 
+func exitWithFailure() throws {
+    throw ExitCode.failure
+}
+
+// MARK: -
+
 public enum ArgumentValidation {
     
     // Call first in the `validate()` method of each command
@@ -153,6 +159,18 @@ public enum ArgumentValidation {
             if outputPath == "none" { .none }
             else if outputPath == "stdout" { throw ValidationError("The output path 'stdout' is not valid for the snapshot command")}
             else { .snapshot(FileUtilities.outputURL(for: outputPath, defaultFileName: defaultFilename)) }
+        }
+    }
+
+    public enum Validate {
+        
+        public static let defaultFilename = "ValidationReport.txt"
+        public static let defaultOutput: ExtractionJob.Output = .validationReport(URL.standardOutURL)
+        
+        // Transforms --output--path argument into an output value
+        @Sendable public static func output(_ outputPath: String) throws -> ExtractionJob.Output {
+            if outputPath == "none" { .none }
+            else { .validationReport(FileUtilities.outputURL(for: outputPath, defaultFileName: defaultFilename)) }
         }
     }
 }

--- a/Sources/EvolutionMetadataExtraction/Utilities/ModelExtenstions.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/ModelExtenstions.swift
@@ -24,4 +24,63 @@ extension EvolutionMetadata {
             return adjustedData
         }
     }
+
+    var hasErrors: Bool { proposals.contains { $0.hasErrors } }
+
+    var validationReport: String {
+        var report = """
+            Swift Evolution Validation Report
+            Generated: \(creationDate)
+            Tool Version: \(toolVersion)\n\n
+            """
+        let errorProposals = proposals.filter { $0.hasIssues }
+        
+        if errorProposals.isEmpty {
+            report += "NO ISSUES FOUND\n"
+        } else {
+            report += "ISSUES FOUND\n\n"
+            report = errorProposals.reduce(into: report) { $0 += $1.validationReport + "\n" }
+        }
+        return report
+    }
+}
+
+// MARK: -
+
+extension Proposal {
+
+    var hasErrors: Bool {
+        if let errors, !errors.isEmpty { true } else { false }
+    }
+    var hasWarnings: Bool {
+        if let warnings, !warnings.isEmpty { true } else { false }
+    }
+    var hasIssues: Bool { hasWarnings || hasErrors }
+
+    var validationReport: String {
+        var report: String = ""
+        if hasErrors || hasWarnings {
+            let adjustedID = id.isEmpty ? "<Missing ID>" : id
+            let adjustedTitle = title.isEmpty ? "<Missing Title>" : "'\(title)'"
+            report += (id.isEmpty && title.isEmpty) ? "<Missing ID & Title>" : "\(adjustedID) \(adjustedTitle)"
+            if !link.isEmpty { report += "\n" + link }
+            report += "\n\n"
+
+            if hasErrors, let errors {
+                report += issuesReport(heading: "ERRORS", issues: errors) + "\n"
+            }
+            if hasWarnings, let warnings {
+                report += issuesReport(heading: "WARNINGS", issues: warnings) + "\n"
+            }
+        }
+        return report
+    }
+
+    private func issuesReport(heading: String, issues: [Proposal.Issue]) -> String {
+        var report = "\t\(heading)\n"
+        for issue in issues {
+            report += "\t\(issue.message)\n"
+        }
+        return report
+    }
 }

--- a/Sources/swift-evolution-metadata-extractor/Help.swift
+++ b/Sources/swift-evolution-metadata-extractor/Help.swift
@@ -82,4 +82,16 @@ enum Help {
                 """
         }
     }
+
+    enum Validate {
+        static let commandName = "validate"
+
+        static let abstract = "Extracts metadata from Swift evolution proposals and generates a validation report."
+
+        static let discussion =  """
+        Running with no arguments will read from the swift-evolution repository, extract metadata and write a validation report to stdout.
+        
+        If validation errors are found the process will exit with error code 1.
+        """
+    }
 }

--- a/Sources/swift-evolution-metadata-extractor/RootCommand.swift
+++ b/Sources/swift-evolution-metadata-extractor/RootCommand.swift
@@ -17,7 +17,7 @@ struct RootCommand: AsyncParsableCommand {
         usage: Help.Root.usage,
         discussion: Help.Root.discussion,
         version: ToolVersion.version,
-        subcommands: [ExtractCommand.self, SnapshotCommand.self],
+        subcommands: [ExtractCommand.self, SnapshotCommand.self, ValidateCommand.self],
         defaultSubcommand: ExtractCommand.self
     )
 }

--- a/Sources/swift-evolution-metadata-extractor/ValidateCommand.swift
+++ b/Sources/swift-evolution-metadata-extractor/ValidateCommand.swift
@@ -1,0 +1,46 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import Foundation
+import ArgumentParser
+import EvolutionMetadataExtraction
+
+struct ValidateCommand: AsyncParsableCommand {
+    
+    static let configuration = CommandConfiguration(
+        commandName: Help.Validate.commandName,
+        abstract: Help.Validate.abstract,
+        discussion: Help.Validate.discussion
+    )
+
+    @Option(name: [.short, .customLong("output-path")], help: Help.Shared.Argument.outputPath, transform: ArgumentValidation.Validate.output)
+    var output: ExtractionJob.Output = ArgumentValidation.Validate.defaultOutput
+
+    @Option(name: .customLong("snapshot-path"), help: Help.Shared.Argument.snapshotPath, transform: ArgumentValidation.snapshotURL)
+    var snapshotURL: URL?
+    var extractionSource: ExtractionJob.Source = .network
+
+    @Flag(name: .shortAndLong, help: Help.Shared.Argument.verbose)
+    var verbose: Bool = false
+
+    @Argument(help: Help.Shared.Argument.proposalFiles, transform: ArgumentValidation.proposalURL)
+    var proposalURLs: [URL] = []
+
+    mutating func validate() throws {
+        ArgumentValidation.validate(verbose: verbose)
+        ArgumentValidation.validateHTTPProxies()
+        extractionSource = try ArgumentValidation.extractionSource(snapshotURL: snapshotURL, proposalURLs: proposalURLs)
+    }
+
+
+    func run() async throws {
+        // Always ignore previous results when generating a validation report
+        let extractionJob = try await ExtractionJob.makeExtractionJob(from: extractionSource, output: output, ignorePreviousResults: true)
+        try await extractionJob.run()
+    }
+}

--- a/Tests/ExtractionTests/ExtractionTests.swift
+++ b/Tests/ExtractionTests/ExtractionTests.swift
@@ -190,6 +190,15 @@ struct `Extraction Tests` {
     func `Warnings and errors`(actualResult: Proposal, expectedResult: Proposal) async throws {
         #expect(actualResult == expectedResult)
     }
+    
+    @Test func `Exit failure for validation report with errors`() async throws {
+        await #expect(processExitsWith: .failure) {
+            let snapshotURL = try urlForSnapshot(named: "Malformed")
+            let source: ExtractionJob.Source = .snapshot(snapshotURL)
+            let extractionJob = try await ExtractionJob.makeExtractionJob(from: source, output: .validationReport(URL.standardOutURL), ignorePreviousResults: true)
+            try await extractionJob.run()
+        }
+    }
 
     // The lines of text in review-dates-good.txt are status headers from swift-evolution repository history
     @Test func `Good dates`() throws {


### PR DESCRIPTION
- Add validate command, command line support, help
- Add initial version of validation report
- Add validation report output type
- Add failure exit when validation errors are found
- Add test for failure code on exit when errors are found
- Update readme and changelong
- Partial implementation towards Issue #9

