### PR TITLE
Remove parameter labels on two factory methods

### DIFF
--- a/Sources/EvolutionMetadataExtraction/ExtractionJob.swift
+++ b/Sources/EvolutionMetadataExtraction/ExtractionJob.swift
@@ -68,7 +68,7 @@ public struct ExtractionJob: Sendable {
 
     }
     
-    public static func makeExtractionJob(from source: Source, output: Output, ignorePreviousResults: Bool = false, forcedExtractionIDs: [String] = [], extractionDate: Date = Date()) async throws -> ExtractionJob {
+    public static func makeExtractionJob(source: Source, output: Output, ignorePreviousResults: Bool = false, forcedExtractionIDs: [String] = [], extractionDate: Date = Date()) async throws -> ExtractionJob {
         switch source {
             case .network:
                 try await makeNetworkExtractionJob(output: output, ignorePreviousResults: ignorePreviousResults, forcedExtractionIDs: forcedExtractionIDs, extractionDate: extractionDate)
@@ -118,7 +118,7 @@ extension ExtractionJob {
  
         verbosePrint("Using local snapshot\n'\(snapshotURL.relativePath)'")
 
-        let sourceSnapshot = try await Snapshot.makeSnapshot(from: snapshotURL, destURL: output.snapshotURL, ignorePreviousResults: ignorePreviousResults, extractionDate: extractionDate)
+        let sourceSnapshot = try await Snapshot.makeSnapshot(snapshotURL: snapshotURL, destURL: output.snapshotURL, ignorePreviousResults: ignorePreviousResults, extractionDate: extractionDate)
 
         let jobMetadata = JobMetadata(commit: sourceSnapshot.branchInfo?.commit.sha, extractionDate: sourceSnapshot.snapshotDate)
                 

--- a/Sources/EvolutionMetadataExtraction/Utilities/Snapshot.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/Snapshot.swift
@@ -43,7 +43,7 @@ struct Snapshot {
         }
     }
 
-    static func makeSnapshot(from snapshotURL: URL, destURL: URL?, ignorePreviousResults: Bool, extractionDate: Date) async throws -> Snapshot{
+    static func makeSnapshot(snapshotURL: URL, destURL: URL?, ignorePreviousResults: Bool, extractionDate: Date) async throws -> Snapshot{
         var proposalListingFound = false
         var previousResultsFound = false
                         

--- a/Sources/swift-evolution-metadata-extractor/ExtractCommand.swift
+++ b/Sources/swift-evolution-metadata-extractor/ExtractCommand.swift
@@ -45,7 +45,7 @@ struct ExtractCommand: AsyncParsableCommand {
 
     
     func run() async throws {
-        let extractionJob = try await ExtractionJob.makeExtractionJob(from: extractionSource, output: output, ignorePreviousResults: forceAll, forcedExtractionIDs: forcedExtractionIDs)
+        let extractionJob = try await ExtractionJob.makeExtractionJob(source: extractionSource, output: output, ignorePreviousResults: forceAll, forcedExtractionIDs: forcedExtractionIDs)
         try await extractionJob.run()
     }
 }

--- a/Sources/swift-evolution-metadata-extractor/SnapshotCommand.swift
+++ b/Sources/swift-evolution-metadata-extractor/SnapshotCommand.swift
@@ -40,7 +40,7 @@ struct SnapshotCommand: AsyncParsableCommand {
 
     func run() async throws {
         // Always ignore previous results when generating a snapshot
-        let extractionJob = try await ExtractionJob.makeExtractionJob(from: extractionSource, output: output, ignorePreviousResults: true)
+        let extractionJob = try await ExtractionJob.makeExtractionJob(source: extractionSource, output: output, ignorePreviousResults: true)
         try await extractionJob.run()
     }
 }

--- a/Sources/swift-evolution-metadata-extractor/ValidateCommand.swift
+++ b/Sources/swift-evolution-metadata-extractor/ValidateCommand.swift
@@ -40,7 +40,7 @@ struct ValidateCommand: AsyncParsableCommand {
 
     func run() async throws {
         // Always ignore previous results when generating a validation report
-        let extractionJob = try await ExtractionJob.makeExtractionJob(from: extractionSource, output: output, ignorePreviousResults: true)
+        let extractionJob = try await ExtractionJob.makeExtractionJob(source: extractionSource, output: output, ignorePreviousResults: true)
         try await extractionJob.run()
     }
 }


### PR DESCRIPTION
Looking ahead to adding an abstraction for projects, refactoring to remove the 'from' parameter label when creating a Snapshot or ExtractionJob.