### PR TITLE
Add abstraction for projects

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let swiftSettings: [SwiftSetting] = [
 
 let package = Package(
     name: "swift-evolution-metadata-extractor",
-    platforms: [ .macOS(.v14) ],
+    platforms: [ .macOS(.v15) ],
     products: [
         .library(name: "EvolutionMetadataModel", targets: ["EvolutionMetadataModel"]),
         .executable(name: "swift-evolution-metadata-extractor", targets: ["swift-evolution-metadata-extractor"])

--- a/Sources/EvolutionMetadataExtraction/ExtractionJob.swift
+++ b/Sources/EvolutionMetadataExtraction/ExtractionJob.swift
@@ -108,7 +108,7 @@ extension ExtractionJob {
 
         let snapshot: Snapshot?
         if case let .snapshot(destURL) = output {
-            snapshot = Snapshot(sourceURL: nil, destURL: destURL, proposalListing: proposalContentItems, directoryContents: [], proposalSpecs: [], previousResults: nil, expectedResults: nil, branchInfo: mainBranchInfo, snapshotDate: extractionDate)
+            snapshot = Snapshot(project: project, sourceURL: nil, destURL: destURL, proposalListing: proposalContentItems, directoryContents: [], proposalSpecs: [], previousResults: nil, expectedResults: nil, branchInfo: mainBranchInfo, snapshotDate: extractionDate)
         } else {
             snapshot = nil
         }
@@ -123,7 +123,7 @@ extension ExtractionJob {
  
         verbosePrint("Using local snapshot\n'\(snapshotURL.relativePath)'")
 
-        let sourceSnapshot = try await Snapshot.makeSnapshot(snapshotURL: snapshotURL, destURL: output.snapshotURL, ignorePreviousResults: ignorePreviousResults, extractionDate: extractionDate)
+        let sourceSnapshot = try await Snapshot.makeSnapshot(project: project, snapshotURL: snapshotURL, destURL: output.snapshotURL, ignorePreviousResults: ignorePreviousResults, extractionDate: extractionDate)
 
         let jobMetadata = JobMetadata(commit: sourceSnapshot.branchInfo?.commit.sha, extractionDate: sourceSnapshot.snapshotDate)
                 
@@ -145,7 +145,7 @@ extension ExtractionJob {
 
         let snapshot: Snapshot?
         if case let .snapshot(destURL) = output {
-            snapshot = Snapshot(sourceURL: nil, destURL: destURL, proposalListing: nil, directoryContents: [], proposalSpecs: [], previousResults: nil, expectedResults: nil, branchInfo: nil, snapshotDate: extractionDate)
+            snapshot = Snapshot(project: project, sourceURL: nil, destURL: destURL, proposalListing: nil, directoryContents: [], proposalSpecs: [], previousResults: nil, expectedResults: nil, branchInfo: nil, snapshotDate: extractionDate)
         } else {
             snapshot = nil
         }
@@ -170,7 +170,7 @@ extension ExtractionJob {
 
         let snapshot: Snapshot?
         if case let .snapshot(destURL) = output {
-            snapshot = Snapshot(sourceURL: nil, destURL: destURL, proposalListing: nil, directoryContents: [], proposalSpecs: [], previousResults: nil, expectedResults: nil, branchInfo: nil, snapshotDate: extractionDate)
+            snapshot = Snapshot(project: project, sourceURL: nil, destURL: destURL, proposalListing: nil, directoryContents: [], proposalSpecs: [], previousResults: nil, expectedResults: nil, branchInfo: nil, snapshotDate: extractionDate)
         } else {
             snapshot = nil
         }

--- a/Sources/EvolutionMetadataExtraction/ExtractionJob.swift
+++ b/Sources/EvolutionMetadataExtraction/ExtractionJob.swift
@@ -101,7 +101,7 @@ extension ExtractionJob {
         // in those subdirectories are filtered out of this proposal
         // specs array.
         let proposalSpecs = proposalContentItems.enumerated().compactMap {
-            $1.proposalSpec(sortIndex: $0)
+            $1.proposalSpec(project: project, sortIndex: $0)
         }
 
         let jobMetadata = JobMetadata(commit: sha, extractionDate: extractionDate)
@@ -139,7 +139,7 @@ extension ExtractionJob {
         let proposalSpecs = fileURLs
             .sorted(using: SortDescriptor(\URL.lastPathComponent, order: .forward))
             .enumerated()
-            .map { ProposalSpec(url: $1, sha: "", sortIndex: $0) }
+            .map { ProposalSpec(project: project, url: $1, sha: "", sortIndex: $0) }
 
         let jobMetadata = JobMetadata(commit: "", extractionDate: extractionDate)
 
@@ -163,7 +163,7 @@ extension ExtractionJob {
         // The proposals/ directory may have subdirectories for proposals from specific workgroups.
         // Proposals in those subdirectories are filtered out of this proposal specs array.
         let proposalSpecs = proposalContentItems.enumerated().compactMap {
-            $1.proposalSpec(sortIndex: $0)
+            $1.proposalSpec(project: project, sortIndex: $0)
         }
 
         let jobMetadata = JobMetadata(commit: "", extractionDate: extractionDate)

--- a/Sources/EvolutionMetadataExtraction/ExtractionJob.swift
+++ b/Sources/EvolutionMetadataExtraction/ExtractionJob.swift
@@ -91,10 +91,10 @@ extension ExtractionJob {
     
     private static func makeNetworkExtractionJob(project: Project, output: Output, ignorePreviousResults: Bool, forcedExtractionIDs: [String], extractionDate: Date) async throws -> ExtractionJob {
         
-        async let previousResults = previousResults(from: PreviousResultsFetcher.previousResultsURL, ignorePreviousResults: ignorePreviousResults)
-        let mainBranchInfo = try await GitHubFetcher.fetchMainBranch()
+        async let previousResults = previousResults(from: project.previousResultsURL, ignorePreviousResults: ignorePreviousResults)
+        let mainBranchInfo = try await GitHubFetcher.fetchMainBranch(for: project)
         let sha = mainBranchInfo.commit.sha
-        let proposalContentItems = try await GitHubFetcher.fetchProposalContentItems(for: sha)
+        let proposalContentItems = try await GitHubFetcher.fetchProposalContentItems(for: project, sha: sha)
 
         // The proposals/ directory may have subdirectories for
         // proposals from specific workgroups. For now, proposals
@@ -158,7 +158,7 @@ extension ExtractionJob {
         // Argument validation should ensure correct values. Assert to catch problems in usage in tests.
         assert(ignorePreviousResults == true && forcedExtractionIDs.isEmpty, "Extraction from a pull request always ignores previous results and performs a full extraction")
 
-        let proposalContentItems = try await GitHubFetcher.fetchPullRequestProposalList(for: pullRequestID)
+        let proposalContentItems = try await GitHubFetcher.fetchPullRequestProposalList(for: project, pullRequestNumber: pullRequestID)
 
         // The proposals/ directory may have subdirectories for proposals from specific workgroups.
         // Proposals in those subdirectories are filtered out of this proposal specs array.

--- a/Sources/EvolutionMetadataExtraction/Extractors/EvolutionMetadataExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/EvolutionMetadataExtractor.swift
@@ -166,13 +166,15 @@ struct EvolutionMetadataExtractor {
 /// The listing of proposals to be processed may come from a GitHub proposal listing or scanning the contents of a directory.
 ///
 struct ProposalSpec: Sendable {
+    let project: Project
     let url: URL
     let sha: String
     let sortIndex: Int
     var id: String { "SE-" + url.lastPathComponent.prefix(4) }
     var filename: String { url.lastPathComponent }
     
-    init(url: URL, sha: String, sortIndex: Int) {
+    init(project: Project, url: URL, sha: String, sortIndex: Int) {
+        self.project = project
         self.url = url
         self.sha = sha
         self.sortIndex = sortIndex

--- a/Sources/EvolutionMetadataExtraction/Extractors/EvolutionMetadataExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/EvolutionMetadataExtractor.swift
@@ -170,7 +170,7 @@ struct ProposalSpec: Sendable {
     let url: URL
     let sha: String
     let sortIndex: Int
-    var id: String { "SE-" + url.lastPathComponent.prefix(4) }
+    var id: String { "\(project.proposalPrefix)-\(url.lastPathComponent.prefix(4))" }
     var filename: String { url.lastPathComponent }
     
     init(project: Project, url: URL, sha: String, sortIndex: Int) {

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/DiscussionExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/DiscussionExtractor.swift
@@ -16,17 +16,17 @@ struct DiscussionExtractor: MarkupWalker, ValueExtractor {
     
     private var discussions: [Proposal.Discussion] = []
 
-    mutating func extractValue(from src: HeaderFieldSource) -> ExtractionResult<[Proposal.Discussion]> {
+    mutating func extractValue(from source: HeaderFieldSource) -> ExtractionResult<[Proposal.Discussion]> {
         
         // VALIDATION ENHANCEMENT: Normalize naming to 'Review' in the source proposals.
-        if let (_, headerField) = src.headerFieldsByLabel[["Review", "Reviews", "Decision Notes", "Decision notes"]] {
+        if let (_, headerField) = source["Review", "Reviews", "Decision Notes", "Decision notes"] {
             visit(headerField)
             
             // VALIDATION ENHANCEMENT: Correct proposals with known issues and remove special case logic.
             // Currently a fair number of older proposals are missing links to discussions or do not
             // format discussions correctly. Those issues should be corrected in the proposals themselves.
             // Once all of those issues are resolved, the legacy check can be removed.
-            if discussions.isEmpty && !Legacy.discussionExtractionFailures.contains(src.proposalSpec.id) {
+            if discussions.isEmpty && !Legacy.discussionExtractionFailures.contains(source.proposalSpec.id) {
                 errors.append(.discussionExtractionFailure)
             }
         } else {
@@ -35,7 +35,7 @@ struct DiscussionExtractor: MarkupWalker, ValueExtractor {
             // field for a variety of reasons. Those issues should be corrected in the proposals themselves.
             // Once all of those issues are resolved, the legacy check can be removed.
             // Note that some very early proposals may not have valid discussions be extracted.
-            if !Legacy.missingReviewFields.contains(src.proposalSpec.id) {
+            if !Legacy.missingReviewFields.contains(source.proposalSpec.id) {
                 errors.append(.missingReviewField)
             }
         }

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/DiscussionExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/DiscussionExtractor.swift
@@ -16,17 +16,17 @@ struct DiscussionExtractor: MarkupWalker, ValueExtractor {
     
     private var discussions: [Proposal.Discussion] = []
 
-    mutating func extractValue(from sourceValues: (headerFieldsByLabel: [String : ListItem], proposalID: String)) -> ExtractionResult<[Proposal.Discussion]> {
+    mutating func extractValue(from src: HeaderFieldSource) -> ExtractionResult<[Proposal.Discussion]> {
         
         // VALIDATION ENHANCEMENT: Normalize naming to 'Review' in the source proposals.
-        if let (_, headerField) = sourceValues.headerFieldsByLabel[["Review", "Reviews", "Decision Notes", "Decision notes"]] {
+        if let (_, headerField) = src.headerFieldsByLabel[["Review", "Reviews", "Decision Notes", "Decision notes"]] {
             visit(headerField)
             
             // VALIDATION ENHANCEMENT: Correct proposals with known issues and remove special case logic.
             // Currently a fair number of older proposals are missing links to discussions or do not
             // format discussions correctly. Those issues should be corrected in the proposals themselves.
             // Once all of those issues are resolved, the legacy check can be removed.
-            if discussions.isEmpty && !Legacy.discussionExtractionFailures.contains(sourceValues.proposalID) {
+            if discussions.isEmpty && !Legacy.discussionExtractionFailures.contains(src.proposalSpec.id) {
                 errors.append(.discussionExtractionFailure)
             }
         } else {
@@ -35,7 +35,7 @@ struct DiscussionExtractor: MarkupWalker, ValueExtractor {
             // field for a variety of reasons. Those issues should be corrected in the proposals themselves.
             // Once all of those issues are resolved, the legacy check can be removed.
             // Note that some very early proposals may not have valid discussions be extracted.
-            if !Legacy.missingReviewFields.contains(sourceValues.proposalID) {
+            if !Legacy.missingReviewFields.contains(src.proposalSpec.id) {
                 errors.append(.missingReviewField)
             }
         }

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/HeaderFieldExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/HeaderFieldExtractor.swift
@@ -17,8 +17,8 @@ struct HeaderFieldExtractor: MarkupWalker, ValueExtractor {
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
     
-    mutating func extractValue(from document: Document) -> ExtractionResult<[String: ListItem]> {
-        guard let headerFields = document.child(through: [(1, UnorderedList.self)]) as? UnorderedList else {
+    mutating func extractValue(from src: DocumentSource) -> ExtractionResult<[String: ListItem]> {
+        guard let headerFields = src.document.child(through: [(1, UnorderedList.self)]) as? UnorderedList else {
             return ExtractionResult(value: nil, warnings: warnings, errors: errors)
         }
         visit(headerFields)

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/ImplementationExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/ImplementationExtractor.swift
@@ -20,8 +20,8 @@ struct ImplementationExtractor: MarkupWalker, ValueExtractor {
     }
     private var _implementaton: [Proposal.Implementation] = []
     
-    mutating func extractValue(from src: HeaderFieldSource) -> ExtractionResult<[Proposal.Implementation]> {
-        if let (_ , headerField) = src.headerFieldsByLabel[["Implementation", "Implementations"]] {
+    mutating func extractValue(from source: HeaderFieldSource) -> ExtractionResult<[Proposal.Implementation]> {
+        if let (_ , headerField) = source["Implementation", "Implementations"] {
             visit(headerField)
         }
         // Implementation field is optional. Take no action / add no warning if it is not found

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/ImplementationExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/ImplementationExtractor.swift
@@ -20,8 +20,8 @@ struct ImplementationExtractor: MarkupWalker, ValueExtractor {
     }
     private var _implementaton: [Proposal.Implementation] = []
     
-    mutating func extractValue(from headerFieldsByLabel: [String : ListItem]) -> ExtractionResult<[Proposal.Implementation]> {
-        if let (_ , headerField) = headerFieldsByLabel[["Implementation", "Implementations"]] {
+    mutating func extractValue(from src: HeaderFieldSource) -> ExtractionResult<[Proposal.Implementation]> {
+        if let (_ , headerField) = src.headerFieldsByLabel[["Implementation", "Implementations"]] {
             visit(headerField)
         }
         // Implementation field is optional. Take no action / add no warning if it is not found

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/PersonExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/PersonExtractor.swift
@@ -10,16 +10,16 @@ import Markdown
 import EvolutionMetadataModel
 
 struct AuthorExtractor: ValueExtractor {
-    func extractValue(from headerFieldsByLabel: [String : ListItem]) -> ExtractionResult<[Proposal.Person]> {
+    func extractValue(from src: HeaderFieldSource) -> ExtractionResult<[Proposal.Person]> {
         var personExtractor = PersonExtractor(role: .author)
-        return personExtractor.personArray(from: headerFieldsByLabel)
+        return personExtractor.personArray(from: src)
     }
 }
 
 struct ReviewManagerExtractor: ValueExtractor {
-    func extractValue(from headerFieldsByLabel: [String : ListItem]) -> ExtractionResult<[Proposal.Person]> {
+    func extractValue(from src: HeaderFieldSource) -> ExtractionResult<[Proposal.Person]> {
         var personExtractor = PersonExtractor(role: .reviewManager)
-        return personExtractor.personArray(from: headerFieldsByLabel)
+        return personExtractor.personArray(from: src)
     }
 }
 
@@ -40,13 +40,13 @@ struct PersonExtractor: MarkupWalker {
         self.role = role
     }
     
-    mutating func personArray(from headerFields: [String : ListItem]) -> ExtractionResult<[Proposal.Person]> {
+    mutating func personArray(from src: HeaderFieldSource) -> ExtractionResult<[Proposal.Person]> {
         let headerLabels = switch role {
             case .author: ["Author", "Authors"]
             // VALIDATION ENHANCEMENT: Normalize capitalization to 'Review Manager'
             case .reviewManager: ["Review manager", "Review Manager", "Review managers", "Review Managers"]
         }
-        if let (_, headerField) = headerFields[headerLabels] {
+        if let (_, headerField) = src.headerFieldsByLabel[headerLabels] {
             visit(headerField)
         }
         

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/PersonExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/PersonExtractor.swift
@@ -40,13 +40,13 @@ struct PersonExtractor: MarkupWalker {
         self.role = role
     }
     
-    mutating func personArray(from src: HeaderFieldSource) -> ExtractionResult<[Proposal.Person]> {
+    mutating func personArray(from source: HeaderFieldSource) -> ExtractionResult<[Proposal.Person]> {
         let headerLabels = switch role {
             case .author: ["Author", "Authors"]
             // VALIDATION ENHANCEMENT: Normalize capitalization to 'Review Manager'
             case .reviewManager: ["Review manager", "Review Manager", "Review managers", "Review Managers"]
         }
-        if let (_, headerField) = src.headerFieldsByLabel[headerLabels] {
+        if let (_, headerField) = source[headerLabels] {
             visit(headerField)
         }
         

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/PreviousProposalExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/PreviousProposalExtractor.swift
@@ -19,9 +19,9 @@ struct PreviousProposalExtractor: MarkupWalker, ValueExtractor {
     }
     private var _previousProposalIDs: [String] = []
     
-    mutating func extractValue(from headerFieldsByLabel: [String : ListItem]) -> ExtractionResult<[String]> {
+    mutating func extractValue(from src: HeaderFieldSource) -> ExtractionResult<[String]> {
         
-        if let prevPropField = headerFieldsByLabel[["Previous Proposal", "Previous Proposals"]] {
+        if let prevPropField = src.headerFieldsByLabel[["Previous Proposal", "Previous Proposals"]] {
             visit(prevPropField.value)
             
             // validate that if the header field is here at least one proposal ID was found

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/PreviousProposalExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/PreviousProposalExtractor.swift
@@ -19,9 +19,9 @@ struct PreviousProposalExtractor: MarkupWalker, ValueExtractor {
     }
     private var _previousProposalIDs: [String] = []
     
-    mutating func extractValue(from src: HeaderFieldSource) -> ExtractionResult<[String]> {
+    mutating func extractValue(from source: HeaderFieldSource) -> ExtractionResult<[String]> {
         
-        if let prevPropField = src.headerFieldsByLabel[["Previous Proposal", "Previous Proposals"]] {
+        if let prevPropField = source["Previous Proposal", "Previous Proposals"] {
             visit(prevPropField.value)
             
             // validate that if the header field is here at least one proposal ID was found

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/ProposalLinkExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/ProposalLinkExtractor.swift
@@ -15,8 +15,8 @@ struct ProposalLinkExtractor: MarkupWalker, ValueExtractor {
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
     
-    mutating func extractValue(from src: HeaderFieldSource) -> ExtractionResult<LinkInfo> {
-        if let headerField = src.headerFieldsByLabel["Proposal"] {
+    mutating func extractValue(from source: HeaderFieldSource) -> ExtractionResult<LinkInfo> {
+        if let headerField = source["Proposal"] {
             visit(headerField)
         } else {
             errors.append(.missingProposalIDLink)
@@ -35,7 +35,7 @@ struct ProposalLinkExtractor: MarkupWalker, ValueExtractor {
                     errors.append(.reservedProposalID)
                 }
                 
-                if !proposalLink.text.contains(src.proposalSpec.project.proposalRegex) {
+                if !proposalLink.text.contains(source.proposalSpec.project.proposalRegex) {
                     self.proposalLink?.destination = "" // Do not include an incorrect destination
                     errors.append(.proposalIDWrongDigitCount)
                 }

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/ProposalLinkExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/ProposalLinkExtractor.swift
@@ -15,8 +15,8 @@ struct ProposalLinkExtractor: MarkupWalker, ValueExtractor {
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
     
-    mutating func extractValue(from headerFieldsByLabel: [String : ListItem]) -> ExtractionResult<LinkInfo> {
-        if let headerField = headerFieldsByLabel["Proposal"] {
+    mutating func extractValue(from src: HeaderFieldSource) -> ExtractionResult<LinkInfo> {
+        if let headerField = src.headerFieldsByLabel["Proposal"] {
             visit(headerField)
         } else {
             errors.append(.missingProposalIDLink)
@@ -35,7 +35,7 @@ struct ProposalLinkExtractor: MarkupWalker, ValueExtractor {
                     errors.append(.reservedProposalID)
                 }
                 
-                if !proposalLink.text.contains(/^SE-\d\d\d\d$/) {
+                if !proposalLink.text.contains(src.proposalSpec.project.proposalRegex) {
                     self.proposalLink?.destination = "" // Do not include an incorrect destination
                     errors.append(.proposalIDWrongDigitCount)
                 }

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/StatusExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/StatusExtractor.swift
@@ -18,12 +18,12 @@ struct StatusExtractor: MarkupWalker, ValueExtractor {
     private var extractionDate: Date = Date()
     var status: Proposal.Status? = nil
     
-    mutating func extractValue(from sourceValues: (src: HeaderFieldSource, extractionDate: Date)) -> ExtractionResult<Proposal.Status> {
+    mutating func extractValue(from sourceValues: (source: HeaderFieldSource, extractionDate: Date)) -> ExtractionResult<Proposal.Status> {
         
         extractionDate = sourceValues.extractionDate
         
         // If 'Status' field not found, report
-        if let headerField = sourceValues.src.headerFieldsByLabel["Status"] {
+        if let headerField = sourceValues.source["Status"] {
             visit(headerField)
         }
         

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/StatusExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/StatusExtractor.swift
@@ -18,12 +18,12 @@ struct StatusExtractor: MarkupWalker, ValueExtractor {
     private var extractionDate: Date = Date()
     var status: Proposal.Status? = nil
     
-    mutating func extractValue(from sourceValues: (headerFieldsByLabel: [String : ListItem], extractionDate: Date)) -> ExtractionResult<Proposal.Status> {
+    mutating func extractValue(from sourceValues: (src: HeaderFieldSource, extractionDate: Date)) -> ExtractionResult<Proposal.Status> {
         
         extractionDate = sourceValues.extractionDate
         
         // If 'Status' field not found, report
-        if let headerField = sourceValues.headerFieldsByLabel["Status"] {
+        if let headerField = sourceValues.src.headerFieldsByLabel["Status"] {
             visit(headerField)
         }
         

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/SummaryExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/SummaryExtractor.swift
@@ -14,11 +14,11 @@ struct SummaryExtractor: ValueExtractor {
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
     
-    func extractValue(from document: Document) -> ExtractionResult<String> {
+    func extractValue(from src: DocumentSource) -> ExtractionResult<String> {
                 
         var summary = ""
         var foundIntroduction = false
-        for child in document.children {
+        for child in src.document.children {
 
             // VALIDATION ENHANCEMENT: Potential for stricter validation of section heading and contents
             // https://github.com/swiftlang/swift-evolution-metadata-extractor/issues/77

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/TitleExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/TitleExtractor.swift
@@ -14,11 +14,11 @@ struct TitleExtractor: ValueExtractor {
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
     
-    mutating func extractValue(from document: Document) -> ExtractionResult<String> {
+    mutating func extractValue(from src: DocumentSource) -> ExtractionResult<String> {
         
         var title: String?
         
-        if let titleElement = document.child(at: 0) as? Heading {
+        if let titleElement = src.document.child(at: 0) as? Heading {
             
             // VALIDATION ENHANCEMENT: Add warning or error that the title is badly formatted in the markdown
 //            if titleElement.level != 1 {

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/TrackingBugExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/TrackingBugExtractor.swift
@@ -19,8 +19,8 @@ struct TrackingBugExtractor: MarkupWalker, ValueExtractor {
     }
     private var _trackingBugs: [Proposal.TrackingBug] = []
     
-    mutating func extractValue(from headerFieldsByLabel: [String : ListItem]) -> ExtractionResult<[Proposal.TrackingBug]> {
-        if let (_, headerField) = headerFieldsByLabel[["Bug", "Bugs"]] {
+    mutating func extractValue(from src: HeaderFieldSource) -> ExtractionResult<[Proposal.TrackingBug]> {
+        if let (_, headerField) = src.headerFieldsByLabel[["Bug", "Bugs"]] {
             visit(headerField)
         }
         

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/TrackingBugExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/TrackingBugExtractor.swift
@@ -19,8 +19,8 @@ struct TrackingBugExtractor: MarkupWalker, ValueExtractor {
     }
     private var _trackingBugs: [Proposal.TrackingBug] = []
     
-    mutating func extractValue(from src: HeaderFieldSource) -> ExtractionResult<[Proposal.TrackingBug]> {
-        if let (_, headerField) = src.headerFieldsByLabel[["Bug", "Bugs"]] {
+    mutating func extractValue(from source: HeaderFieldSource) -> ExtractionResult<[Proposal.TrackingBug]> {
+        if let (_, headerField) = source["Bug", "Bugs"] {
             visit(headerField)
         }
         

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/UpcomingFeatureFlagExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/UpcomingFeatureFlagExtractor.swift
@@ -24,9 +24,9 @@ struct UpcomingFeatureFlagExtractor: MarkupWalker, ValueExtractor {
         }
     }
 
-    mutating func extractValue(from headerFieldsByLabel: [String : ListItem]) -> ExtractionResult<Proposal.UpcomingFeatureFlag> {
+    mutating func extractValue(from src: HeaderFieldSource) -> ExtractionResult<Proposal.UpcomingFeatureFlag> {
         
-        if let uffField = headerFieldsByLabel["Upcoming Feature Flag"] {
+        if let uffField = src.headerFieldsByLabel["Upcoming Feature Flag"] {
             visit(uffField)
             
             // validate that flag is extracted if header is present

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/UpcomingFeatureFlagExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/UpcomingFeatureFlagExtractor.swift
@@ -24,9 +24,9 @@ struct UpcomingFeatureFlagExtractor: MarkupWalker, ValueExtractor {
         }
     }
 
-    mutating func extractValue(from src: HeaderFieldSource) -> ExtractionResult<Proposal.UpcomingFeatureFlag> {
+    mutating func extractValue(from source: HeaderFieldSource) -> ExtractionResult<Proposal.UpcomingFeatureFlag> {
         
-        if let uffField = src.headerFieldsByLabel["Upcoming Feature Flag"] {
+        if let uffField = source["Upcoming Feature Flag"] {
             visit(uffField)
             
             // validate that flag is extracted if header is present

--- a/Sources/EvolutionMetadataExtraction/Extractors/ProposalMetadataExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/ProposalMetadataExtractor.swift
@@ -18,6 +18,9 @@ struct DocumentSource {
 struct HeaderFieldSource {
     let proposalSpec: ProposalSpec
     let headerFieldsByLabel: [String : ListItem]
+    subscript(key: String) -> ListItem? { headerFieldsByLabel[key] }
+    subscript(key: [String]) -> (key: String, value: ListItem)? { headerFieldsByLabel[key] }
+    subscript(key: String...) -> (key: String, value: ListItem)? { headerFieldsByLabel[key] }
 }
 
 struct ProposalMetadataExtractor {

--- a/Sources/EvolutionMetadataExtraction/Utilities/Networking.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/Networking.swift
@@ -59,9 +59,9 @@ struct GitHubContentItem: Codable {
 
     /// Returns `nil` if this content item corresponds to a
     /// subdirectory instead of a direct proposal document.
-    func proposalSpec(sortIndex: Int) ->  ProposalSpec? {
+    func proposalSpec(project: Project, sortIndex: Int) ->  ProposalSpec? {
         guard let download_url else { return nil }
-        return ProposalSpec(url: URL(string: download_url)!, sha: sha, sortIndex: sortIndex)
+        return ProposalSpec(project: project, url: URL(string: download_url)!, sha: sha, sortIndex: sortIndex)
     }
 }
 
@@ -83,8 +83,8 @@ struct GitHubPullFileItem: Codable {
         filename.hasSuffix(".md")
     }
 
-    func proposalSpec(sortIndex: Int) ->  ProposalSpec {
-        ProposalSpec(url: URL(string: raw_url)!, sha: sha, sortIndex: sortIndex)
+    func proposalSpec(project: Project, sortIndex: Int) ->  ProposalSpec {
+        ProposalSpec(project: project, url: URL(string: raw_url)!, sha: sha, sortIndex: sortIndex)
     }
 
 }

--- a/Sources/EvolutionMetadataExtraction/Utilities/Project.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/Project.swift
@@ -16,7 +16,7 @@ public final class Project: Sendable {
     let organization: String
     let repository: String
     let path: String
-    let projectPrefix: String
+    let proposalPrefix: String
     nonisolated(unsafe) let proposalRegex: Regex<Substring>
     let previousResultsURL: URL
     let defaultOutputFilename: String
@@ -25,12 +25,12 @@ public final class Project: Sendable {
     let proposalListingEndpoint: URL
     let validationExclusions: [Int:RangeSet<Int>]
     
-    private init(name: String, organization: String, repository: String, path: String, projectPrefix: String, proposalRegex: Regex<Substring>, previousResultsURL: URL, defaultOutputFilename: String, validationExclusions: [Int:RangeSet<Int>]) {
+    private init(name: String, organization: String, repository: String, path: String, proposalPrefix: String, proposalRegex: Regex<Substring>, previousResultsURL: URL, defaultOutputFilename: String, validationExclusions: [Int:RangeSet<Int>]) {
         self.name = name
         self.organization = organization
         self.repository = repository
         self.path = path
-        self.projectPrefix = projectPrefix
+        self.proposalPrefix = proposalPrefix
         self.proposalRegex = proposalRegex
         self.previousResultsURL = previousResultsURL
         self.defaultOutputFilename = defaultOutputFilename
@@ -55,7 +55,7 @@ public final class Project: Sendable {
         organization: "swiftlang",
         repository: "swift-evolution",
         path: "proposals",
-        projectPrefix: "SE-",
+        proposalPrefix: "SE",
         proposalRegex: /^SE-\d\d\d\d$/,
         previousResultsURL: URL(string: "https://download.swift.org/swift-evolution/v1/evolution.json")!,
         defaultOutputFilename: "evolution.json",
@@ -67,7 +67,7 @@ public final class Project: Sendable {
         organization: "swiftlang",
         repository: "swift-evolution",
         path: "proposals/testing",
-        projectPrefix: "ST-",
+        proposalPrefix: "ST",
         proposalRegex: /^ST-\d\d\d\d$/,
         previousResultsURL: URL(string: "https://download.swift.org/swift-evolution/v1/testing-evolution.json")!,
         defaultOutputFilename: "testing-evolution.json",
@@ -79,7 +79,7 @@ public final class Project: Sendable {
         organization: "swiftlang",
         repository: "swift-foundation",
         path: "Proposals",
-        projectPrefix: "SF-",
+        proposalPrefix: "SF",
         proposalRegex: /^SF-\d\d\d\d$/,
         previousResultsURL: URL(string: "https://download.swift.org/swift-evolution/v1/foundation-evolution.json")!,
         defaultOutputFilename: "foundation-evolution.json",

--- a/Sources/EvolutionMetadataExtraction/Utilities/Project.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/Project.swift
@@ -20,6 +20,7 @@ public final class Project: Sendable {
     nonisolated(unsafe) let proposalRegex: Regex<Substring>
     let previousResultsURL: URL
     let defaultOutputFilename: String
+    private let endpointBaseURL: URL
     let mainBranchEndpoint: URL
     let proposalListingEndpoint: URL
     let validationExclusions: [Int:RangeSet<Int>]
@@ -35,9 +36,14 @@ public final class Project: Sendable {
         self.defaultOutputFilename = defaultOutputFilename
         self.validationExclusions = validationExclusions
 
-        let endpointBaseURL = URL(string: "https://api.github.com/repos/")!.appending(components: organization, repository)
+        self.endpointBaseURL = URL(string: "https://api.github.com/repos/")!.appending(components: organization, repository)
         self.mainBranchEndpoint = endpointBaseURL.appending(path:"branches/main")
         self.proposalListingEndpoint = endpointBaseURL.appending(path: "contents/" + path)
+    }
+
+    func githubPullEndpoint(for request: Int) -> URL {
+        endpointBaseURL.appending(path: "pulls/\(request)/files")
+            .appending(queryItems: [URLQueryItem(name: "per_page", value: "100")])
     }
 
     public static var `default`: Project {

--- a/Sources/EvolutionMetadataExtraction/Utilities/Project.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/Project.swift
@@ -23,9 +23,9 @@ public final class Project: Sendable {
     private let endpointBaseURL: URL
     let mainBranchEndpoint: URL
     let proposalListingEndpoint: URL
-    let validationExclusions: [Int:RangeSet<Int>]
+    let validationExemptions: [Int:RangeSet<Int>]
     
-    private init(name: String, organization: String, repository: String, path: String, proposalPrefix: String, proposalRegex: Regex<Substring>, previousResultsURL: URL, defaultOutputFilename: String, validationExclusions: [Int:RangeSet<Int>]) {
+    private init(name: String, organization: String, repository: String, path: String, proposalPrefix: String, proposalRegex: Regex<Substring>, previousResultsURL: URL, defaultOutputFilename: String, validationExemptions: [Int:RangeSet<Int>]) {
         self.name = name
         self.organization = organization
         self.repository = repository
@@ -34,7 +34,7 @@ public final class Project: Sendable {
         self.proposalRegex = proposalRegex
         self.previousResultsURL = previousResultsURL
         self.defaultOutputFilename = defaultOutputFilename
-        self.validationExclusions = validationExclusions
+        self.validationExemptions = validationExemptions
 
         self.endpointBaseURL = URL(string: "https://api.github.com/repos/")!.appending(components: organization, repository)
         self.mainBranchEndpoint = endpointBaseURL.appending(path:"branches/main")
@@ -59,7 +59,7 @@ public final class Project: Sendable {
         proposalRegex: /^SE-\d\d\d\d$/,
         previousResultsURL: URL(string: "https://download.swift.org/swift-evolution/v1/evolution.json")!,
         defaultOutputFilename: "evolution.json",
-        validationExclusions: [:]
+        validationExemptions: [:]
     )
 
     public static let swiftTesting = Project(
@@ -71,7 +71,7 @@ public final class Project: Sendable {
         proposalRegex: /^ST-\d\d\d\d$/,
         previousResultsURL: URL(string: "https://download.swift.org/swift-evolution/v1/testing-evolution.json")!,
         defaultOutputFilename: "testing-evolution.json",
-        validationExclusions: [:]
+        validationExemptions: [:]
     )
 
     public static let foundation = Project(
@@ -83,6 +83,6 @@ public final class Project: Sendable {
         proposalRegex: /^SF-\d\d\d\d$/,
         previousResultsURL: URL(string: "https://download.swift.org/swift-evolution/v1/foundation-evolution.json")!,
         defaultOutputFilename: "foundation-evolution.json",
-        validationExclusions: [:]
+        validationExemptions: [:]
     )
 }

--- a/Sources/EvolutionMetadataExtraction/Utilities/Project.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/Project.swift
@@ -1,0 +1,82 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import Foundation
+
+/**
+ Represents a software project with its own set of evolution proposals.
+ */
+public final class Project: Sendable {
+    let name: String
+    let organization: String
+    let repository: String
+    let path: String
+    let projectPrefix: String
+    nonisolated(unsafe) let proposalRegex: Regex<Substring>
+    let previousResultsURL: URL
+    let defaultOutputFilename: String
+    let mainBranchEndpoint: URL
+    let proposalListingEndpoint: URL
+    let validationExclusions: [Int:RangeSet<Int>]
+    
+    private init(name: String, organization: String, repository: String, path: String, projectPrefix: String, proposalRegex: Regex<Substring>, previousResultsURL: URL, defaultOutputFilename: String, validationExclusions: [Int:RangeSet<Int>]) {
+        self.name = name
+        self.organization = organization
+        self.repository = repository
+        self.path = path
+        self.projectPrefix = projectPrefix
+        self.proposalRegex = proposalRegex
+        self.previousResultsURL = previousResultsURL
+        self.defaultOutputFilename = defaultOutputFilename
+        self.validationExclusions = validationExclusions
+
+        let endpointBaseURL = URL(string: "https://api.github.com/repos/")!.appending(components: organization, repository)
+        self.mainBranchEndpoint = endpointBaseURL.appending(path:"branches/main")
+        self.proposalListingEndpoint = endpointBaseURL.appending(path: "contents/" + path)
+    }
+
+    public static var `default`: Project {
+        swift
+    }
+
+    public static let swift = Project(
+        name: "Swift",
+        organization: "swiftlang",
+        repository: "swift-evolution",
+        path: "proposals",
+        projectPrefix: "SE-",
+        proposalRegex: /^SE-\d\d\d\d$/,
+        previousResultsURL: URL(string: "https://download.swift.org/swift-evolution/v1/evolution.json")!,
+        defaultOutputFilename: "evolution.json",
+        validationExclusions: [:]
+    )
+
+    public static let swiftTesting = Project(
+        name: "Swift Testing",
+        organization: "swiftlang",
+        repository: "swift-evolution",
+        path: "proposals/testing",
+        projectPrefix: "ST-",
+        proposalRegex: /^ST-\d\d\d\d$/,
+        previousResultsURL: URL(string: "https://download.swift.org/swift-evolution/v1/testing-evolution.json")!,
+        defaultOutputFilename: "testing-evolution.json",
+        validationExclusions: [:]
+    )
+
+    public static let foundation = Project(
+        name: "Foundation",
+        organization: "swiftlang",
+        repository: "swift-foundation",
+        path: "Proposals",
+        projectPrefix: "SF-",
+        proposalRegex: /^SF-\d\d\d\d$/,
+        previousResultsURL: URL(string: "https://download.swift.org/swift-evolution/v1/foundation-evolution.json")!,
+        defaultOutputFilename: "foundation-evolution.json",
+        validationExclusions: [:]
+    )
+}

--- a/Sources/EvolutionMetadataExtraction/Utilities/Snapshot.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/Snapshot.swift
@@ -61,13 +61,13 @@ struct Snapshot {
             .sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
             .filter { $0.pathExtension == "md"}
             .enumerated()
-            .map { ProposalSpec(url: $1, sha: "", sortIndex: $0) } // try! SHA1.hexForData(Data(contentsOf: $0)))
+            .map { ProposalSpec(project: project, url: $1, sha: "", sortIndex: $0) } // try! SHA1.hexForData(Data(contentsOf: $0)))
 
         let proposalSpecs: [ProposalSpec]
         let proposalListing: [GitHubContentItem]?
         if let contentItems = try FileUtilities.decode([GitHubContentItem].self, from: proposalListingURL) {
             proposalListing = contentItems
-            proposalSpecs = contentItems.enumerated().map { ProposalSpec(url: snapshotURL.appending(path: $1.path), sha: $1.sha, sortIndex: $0) }
+            proposalSpecs = contentItems.enumerated().map { ProposalSpec(project: project, url: snapshotURL.appending(path: $1.path), sha: $1.sha, sortIndex: $0) }
             proposalListingFound = true
             if directoryContents.count != proposalSpecs.count {
                 print("WARNING: Number of proposals in proposals directory does not match number of proposals in 'proposal-listing.json")

--- a/Sources/EvolutionMetadataExtraction/Utilities/Snapshot.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/Snapshot.swift
@@ -10,6 +10,7 @@ import Foundation
 import EvolutionMetadataModel
 
 struct Snapshot {
+    let project: Project
     let sourceURL: URL?
     let destURL: URL?
     var proposalListing: [GitHubContentItem]? = nil // Ad-hoc snapshots may not have these
@@ -23,7 +24,8 @@ struct Snapshot {
     let temporarySnapshotDirectory: URL?
     let temporaryProposalsDirectory: URL?
     
-    init(sourceURL: URL?, destURL: URL?, proposalListing: [GitHubContentItem]?, directoryContents: [ProposalSpec], proposalSpecs: [ProposalSpec], previousResults: EvolutionMetadata?, expectedResults: EvolutionMetadata?, branchInfo: GitHubBranch?, snapshotDate: Date) {
+    init(project: Project, sourceURL: URL?, destURL: URL?, proposalListing: [GitHubContentItem]?, directoryContents: [ProposalSpec], proposalSpecs: [ProposalSpec], previousResults: EvolutionMetadata?, expectedResults: EvolutionMetadata?, branchInfo: GitHubBranch?, snapshotDate: Date) {
+        self.project = project
         self.sourceURL = sourceURL
         self.destURL = destURL
         self.proposalListing = proposalListing
@@ -43,7 +45,7 @@ struct Snapshot {
         }
     }
 
-    static func makeSnapshot(snapshotURL: URL, destURL: URL?, ignorePreviousResults: Bool, extractionDate: Date) async throws -> Snapshot{
+    static func makeSnapshot(project: Project = Project.default, snapshotURL: URL, destURL: URL?, ignorePreviousResults: Bool, extractionDate: Date) async throws -> Snapshot{
         var proposalListingFound = false
         var previousResultsFound = false
                         
@@ -100,7 +102,7 @@ struct Snapshot {
                     Proposal count: \(proposalSpecs.count)
                     """)
         
-        return Snapshot(sourceURL: snapshotURL, destURL: destURL, proposalListing: proposalListing, directoryContents: directoryContents, proposalSpecs: proposalSpecs, previousResults: previousResults, expectedResults: expectedResults, branchInfo: branchInfo, snapshotDate: snapshotDate)
+        return Snapshot(project: project, sourceURL: snapshotURL, destURL: destURL, proposalListing: proposalListing, directoryContents: directoryContents, proposalSpecs: proposalSpecs, previousResults: previousResults, expectedResults: expectedResults, branchInfo: branchInfo, snapshotDate: snapshotDate)
 
 
         // Expected test file directory structure:


### PR DESCRIPTION
Currently, values like the repository URL, proposal prefix (e.g. "SE-"), and a variety of other project-specific values are hard-coded.

Adding an abstraction for projects is a large part of the underpinnings for supporting additional projects #49.

As the extractor tool begins to be used for validation reports in CI, there is also a need for a generalized mechanism for defining validation exemptions on a per-proposal basis. #32 

Looking ahead to supporting multiple projects, these exemptions should also be on a per-project basis.

This PR adds a Project type which contains project-specific info.

The new project type is passed to the extraction job, each proposal spec, and accessible to every extractor, to allow for easy access to validation exemptions.

Note that additional static projects for Swift Testing and Foundation are defined in this PR, but functionality to use the tool with additional projects will be added in #49.  The main reason for sequencing this now is to add the mechanism for validation exemptions.