### PR TITLE
Refactor extractors to be initialized with source

### DIFF
--- a/Sources/EvolutionMetadataExtraction/Extractors/EvolutionMetadataExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/EvolutionMetadataExtractor.swift
@@ -169,6 +169,7 @@ struct ProposalSpec: Sendable {
     let project: Project
     let url: URL
     let sha: String
+    let number: Int
     let sortIndex: Int
     var id: String { "\(project.proposalPrefix)-\(url.lastPathComponent.prefix(4))" }
     var filename: String { url.lastPathComponent }
@@ -177,6 +178,7 @@ struct ProposalSpec: Sendable {
         self.project = project
         self.url = url
         self.sha = sha
+        self.number = Int(url.lastPathComponent.prefix(4)) ?? -1
         self.sortIndex = sortIndex
     }
 }

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/DiscussionExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/DiscussionExtractor.swift
@@ -11,12 +11,15 @@ import EvolutionMetadataModel
 
 struct DiscussionExtractor: MarkupWalker, ValueExtractor {
     
+    private var source: HeaderFieldSource
+    init(source: HeaderFieldSource) { self.source = source }
+
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
     
     private var discussions: [Proposal.Discussion] = []
 
-    mutating func extractValue(from source: HeaderFieldSource) -> ExtractionResult<[Proposal.Discussion]> {
+    mutating func extractValue() -> ExtractionResult<[Proposal.Discussion]> {
         
         // VALIDATION ENHANCEMENT: Normalize naming to 'Review' in the source proposals.
         if let (_, headerField) = source["Review", "Reviews", "Decision Notes", "Decision notes"] {

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/HeaderFieldExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/HeaderFieldExtractor.swift
@@ -12,13 +12,16 @@ import EvolutionMetadataModel
 // VALIDATION ENHANCEMENT: Add test that checks against valid header field labels
 struct HeaderFieldExtractor: MarkupWalker, ValueExtractor {
 
-    private var headerItemsByLabel: [String: ListItem] = [:]
+    private var source: DocumentSource
+    init(source: DocumentSource) { self.source = source }
 
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
-    
-    mutating func extractValue(from src: DocumentSource) -> ExtractionResult<[String: ListItem]> {
-        guard let headerFields = src.document.child(through: [(1, UnorderedList.self)]) as? UnorderedList else {
+
+    private var headerItemsByLabel: [String: ListItem] = [:]
+
+    mutating func extractValue() -> ExtractionResult<[String: ListItem]> {
+        guard let headerFields = source.document.child(through: [(1, UnorderedList.self)]) as? UnorderedList else {
             return ExtractionResult(value: nil, warnings: warnings, errors: errors)
         }
         visit(headerFields)

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/ImplementationExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/ImplementationExtractor.swift
@@ -12,6 +12,9 @@ import EvolutionMetadataModel
 
 struct ImplementationExtractor: MarkupWalker, ValueExtractor {
 
+    private var source: HeaderFieldSource
+    init(source: HeaderFieldSource) { self.source = source }
+
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
 
@@ -20,7 +23,7 @@ struct ImplementationExtractor: MarkupWalker, ValueExtractor {
     }
     private var _implementaton: [Proposal.Implementation] = []
     
-    mutating func extractValue(from source: HeaderFieldSource) -> ExtractionResult<[Proposal.Implementation]> {
+    mutating func extractValue() -> ExtractionResult<[Proposal.Implementation]> {
         if let (_ , headerField) = source["Implementation", "Implementations"] {
             visit(headerField)
         }

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/PersonExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/PersonExtractor.swift
@@ -10,16 +10,20 @@ import Markdown
 import EvolutionMetadataModel
 
 struct AuthorExtractor: ValueExtractor {
-    func extractValue(from src: HeaderFieldSource) -> ExtractionResult<[Proposal.Person]> {
-        var personExtractor = PersonExtractor(role: .author)
-        return personExtractor.personArray(from: src)
+    private let source: HeaderFieldSource
+    init(source: HeaderFieldSource) { self.source = source }
+    func extractValue() -> ExtractionResult<[Proposal.Person]> {
+        var personExtractor = PersonExtractor(source: source, role: .author)
+        return personExtractor.personArray()
     }
 }
 
 struct ReviewManagerExtractor: ValueExtractor {
-    func extractValue(from src: HeaderFieldSource) -> ExtractionResult<[Proposal.Person]> {
-        var personExtractor = PersonExtractor(role: .reviewManager)
-        return personExtractor.personArray(from: src)
+    private let source: HeaderFieldSource
+    init(source: HeaderFieldSource) { self.source = source }
+    func extractValue() -> ExtractionResult<[Proposal.Person]> {
+        var personExtractor = PersonExtractor(source: source, role: .reviewManager)
+        return personExtractor.personArray()
     }
 }
 
@@ -28,19 +32,20 @@ struct PersonExtractor: MarkupWalker {
         case author
         case reviewManager
     }
-    
+
+    private var source: HeaderFieldSource
     private var role: Role
+    init(source: HeaderFieldSource, role: Role) {
+        self.source = source
+        self.role = role
+    }
     
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
 
     private var personList: [Proposal.Person] = []
-    
-    init(role: Role) {
-        self.role = role
-    }
-    
-    mutating func personArray(from source: HeaderFieldSource) -> ExtractionResult<[Proposal.Person]> {
+
+    mutating func personArray() -> ExtractionResult<[Proposal.Person]> {
         let headerLabels = switch role {
             case .author: ["Author", "Authors"]
             // VALIDATION ENHANCEMENT: Normalize capitalization to 'Review Manager'

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/PreviousProposalExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/PreviousProposalExtractor.swift
@@ -10,16 +10,19 @@ import Markdown
 import EvolutionMetadataModel
 
 struct PreviousProposalExtractor: MarkupWalker, ValueExtractor {
-    
+
+    private var source: HeaderFieldSource
+    init(source: HeaderFieldSource) { self.source = source }
+
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
-    
+
     private var previousProposalIDs: [String]? {
         _previousProposalIDs.isEmpty ? nil : _previousProposalIDs
     }
     private var _previousProposalIDs: [String] = []
-    
-    mutating func extractValue(from source: HeaderFieldSource) -> ExtractionResult<[String]> {
+
+    mutating func extractValue() -> ExtractionResult<[String]> {
         
         if let prevPropField = source["Previous Proposal", "Previous Proposals"] {
             visit(prevPropField.value)

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/ProposalLinkExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/ProposalLinkExtractor.swift
@@ -11,11 +11,15 @@ import EvolutionMetadataModel
 
 struct ProposalLinkExtractor: MarkupWalker, ValueExtractor {
     
-    private var proposalLink: LinkInfo? = nil
+    private var source: HeaderFieldSource
+    init(source: HeaderFieldSource) { self.source = source }
+
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
-    
-    mutating func extractValue(from source: HeaderFieldSource) -> ExtractionResult<LinkInfo> {
+
+    private var proposalLink: LinkInfo? = nil
+
+    mutating func extractValue() -> ExtractionResult<LinkInfo> {
         if let headerField = source["Proposal"] {
             visit(headerField)
         } else {
@@ -35,7 +39,7 @@ struct ProposalLinkExtractor: MarkupWalker, ValueExtractor {
                     errors.append(.reservedProposalID)
                 }
                 
-                if !proposalLink.text.contains(source.proposalSpec.project.proposalRegex) {
+                if !proposalLink.text.contains(source.project.proposalRegex) {
                     self.proposalLink?.destination = "" // Do not include an incorrect destination
                     errors.append(.proposalIDWrongDigitCount)
                 }
@@ -54,10 +58,6 @@ struct ProposalLinkExtractor: MarkupWalker, ValueExtractor {
     }
     
     mutating func visitLink(_ link: Link) -> () {
-        guard let value = LinkInfo(link: link) else {
-            errors.append(.missingProposalIDLink)
-            return
-        }
-        proposalLink = value
+        proposalLink = LinkInfo(link: link)
     }
 }

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/SummaryExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/SummaryExtractor.swift
@@ -10,15 +10,18 @@ import Markdown
 import EvolutionMetadataModel
 
 struct SummaryExtractor: ValueExtractor {
-    
+
+    private var source: DocumentSource
+    init(source: DocumentSource) { self.source = source }
+
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
-    
-    func extractValue(from src: DocumentSource) -> ExtractionResult<String> {
-                
+
+    func extractValue() -> ExtractionResult<String> {
+
         var summary = ""
         var foundIntroduction = false
-        for child in src.document.children {
+        for child in source.document.children {
 
             // VALIDATION ENHANCEMENT: Potential for stricter validation of section heading and contents
             // https://github.com/swiftlang/swift-evolution-metadata-extractor/issues/77

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/TitleExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/TitleExtractor.swift
@@ -10,15 +10,18 @@ import Markdown
 import EvolutionMetadataModel
 
 struct TitleExtractor: ValueExtractor {
-    
+
+    private var source: DocumentSource
+    init(source: DocumentSource) { self.source = source }
+
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
-    
-    mutating func extractValue(from src: DocumentSource) -> ExtractionResult<String> {
+
+    mutating func extractValue() -> ExtractionResult<String> {
         
         var title: String?
         
-        if let titleElement = src.document.child(at: 0) as? Heading {
+        if let titleElement = source.document.child(at: 0) as? Heading {
             
             // VALIDATION ENHANCEMENT: Add warning or error that the title is badly formatted in the markdown
 //            if titleElement.level != 1 {

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/TrackingBugExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/TrackingBugExtractor.swift
@@ -11,6 +11,9 @@ import EvolutionMetadataModel
 
 struct TrackingBugExtractor: MarkupWalker, ValueExtractor {
 
+    private var source: HeaderFieldSource
+    init(source: HeaderFieldSource) { self.source = source }
+
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
 
@@ -18,8 +21,8 @@ struct TrackingBugExtractor: MarkupWalker, ValueExtractor {
         _trackingBugs.isEmpty ? nil : _trackingBugs
     }
     private var _trackingBugs: [Proposal.TrackingBug] = []
-    
-    mutating func extractValue(from source: HeaderFieldSource) -> ExtractionResult<[Proposal.TrackingBug]> {
+
+    mutating func extractValue() -> ExtractionResult<[Proposal.TrackingBug]> {
         if let (_, headerField) = source["Bug", "Bugs"] {
             visit(headerField)
         }

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/UpcomingFeatureFlagExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/UpcomingFeatureFlagExtractor.swift
@@ -10,12 +10,15 @@ import Markdown
 import EvolutionMetadataModel
 
 struct UpcomingFeatureFlagExtractor: MarkupWalker, ValueExtractor {
-    
+
+    private var source: HeaderFieldSource
+    init(source: HeaderFieldSource) { self.source = source }
+
     private var warnings: [Proposal.Issue] = []
     private var errors: [Proposal.Issue] = []
-    
+
     private var flag: String?
-    
+
     private var uff: Proposal.UpcomingFeatureFlag? {
         if let flag {
             return Proposal.UpcomingFeatureFlag(flag: flag)
@@ -24,7 +27,7 @@ struct UpcomingFeatureFlagExtractor: MarkupWalker, ValueExtractor {
         }
     }
 
-    mutating func extractValue(from source: HeaderFieldSource) -> ExtractionResult<Proposal.UpcomingFeatureFlag> {
+    mutating func extractValue() -> ExtractionResult<Proposal.UpcomingFeatureFlag> {
         
         if let uffField = source["Upcoming Feature Flag"] {
             visit(uffField)

--- a/Sources/EvolutionMetadataExtraction/Extractors/ProposalMetadataExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/ProposalMetadataExtractor.swift
@@ -10,19 +10,6 @@ import Foundation
 import Markdown
 import EvolutionMetadataModel
 
-struct DocumentSource {
-    let proposalSpec: ProposalSpec
-    let document: Document
-}
-
-struct HeaderFieldSource {
-    let proposalSpec: ProposalSpec
-    let headerFieldsByLabel: [String : ListItem]
-    subscript(key: String) -> ListItem? { headerFieldsByLabel[key] }
-    subscript(key: [String]) -> (key: String, value: ListItem)? { headerFieldsByLabel[key] }
-    subscript(key: String...) -> (key: String, value: ListItem)? { headerFieldsByLabel[key] }
-}
-
 struct ProposalMetadataExtractor {
     
     /// Extracts the metadata from a Swift Evolution proposal
@@ -188,6 +175,39 @@ struct LinkInfo {
         }
     }
 }
+
+// Protocol and structs to encapsulate source information for extractors
+
+protocol IssueSource {
+    var project: Project { get }
+    var proposalNumber: Int { get }
+}
+
+struct DocumentSource: IssueSource {
+    private let proposalSpec: ProposalSpec
+    let document: Document
+    var project: Project { proposalSpec.project }
+    var proposalNumber: Int { proposalSpec.number }
+    init(proposalSpec: ProposalSpec, document: Document) {
+        self.proposalSpec = proposalSpec
+        self.document = document
+    }
+}
+
+struct HeaderFieldSource: IssueSource {
+    let proposalSpec: ProposalSpec
+    let headerFieldsByLabel: [String : ListItem]
+    var project: Project { proposalSpec.project }
+    var proposalNumber: Int { proposalSpec.number }
+    subscript(key: String) -> ListItem? { headerFieldsByLabel[key] }
+    subscript(key: [String]) -> (key: String, value: ListItem)? { headerFieldsByLabel[key] }
+    subscript(key: String...) -> (key: String, value: ListItem)? { headerFieldsByLabel[key] }
+    init(proposalSpec: ProposalSpec, headerFieldsByLabel: [String : ListItem]) {
+        self.proposalSpec = proposalSpec
+        self.headerFieldsByLabel = headerFieldsByLabel
+    }
+}
+
 
 
 

--- a/Sources/EvolutionMetadataExtraction/Extractors/ProposalMetadataExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/ProposalMetadataExtractor.swift
@@ -27,8 +27,8 @@ struct ProposalMetadataExtractor {
         var errors: [Proposal.Issue] = []
         
         func extractValue<T: ValueExtractor>(from source: T.Source, with extractorType: T.Type) -> T.ResultValue? {
-            var extractor = extractorType.init()
-            let result = extractor.extractValue(from: source)
+            var extractor = extractorType.init(source: source)
+            let result = extractor.extractValue()
             warnings.append(contentsOf: result.warnings)
             errors.append(contentsOf: result.errors)
             return result.value
@@ -110,8 +110,8 @@ struct ProposalMetadataExtractor {
 protocol ValueExtractor {
     associatedtype Source
     associatedtype ResultValue
-    mutating func extractValue(from source: Source) -> ExtractionResult<ResultValue>
-    init()
+    init(source: Source)
+    mutating func extractValue() -> ExtractionResult<ResultValue>
 }
 
 /* Returns an optional value and parsing or validation warnings and errors.


### PR DESCRIPTION
Refactor extractors to be initialized with source.

Errors are generated during the swift-markdown visitor methods and need access to the source project and proposal number to determine validation exemptions. This change adds a source property to each extractor so the required information is available.