### PR TITLE
Remove warning for proposals with past due review period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ Add new items at the end of the relevant section under **Unreleased**.
 - Support extraction of new "Summary of changes" section ([#79])
 - Errors and warnings now include unique error codes ([#90])
 - Add generalized mechanism for validation exemptions ([#92])
-- Promote warnings to errors:
+- Promote warnings to errors ([#93])
     - 'missing review manager'
     - 'missing review manager link'
     - 'missing author link'
+- Remove warning for proposals with past due review period ([#94])
 
 ### Fixes
 
@@ -93,3 +94,5 @@ This changelog's format is based on [Keep a Changelog](https://keepachangelog.co
 [#87]: https://github.com/swiftlang/swift-evolution-metadata-extractor/pull/87
 [#90]: https://github.com/swiftlang/swift-evolution-metadata-extractor/pull/90
 [#92]: https://github.com/swiftlang/swift-evolution-metadata-extractor/pull/92
+[#93]: https://github.com/swiftlang/swift-evolution-metadata-extractor/pull/93
+[#94]: https://github.com/swiftlang/swift-evolution-metadata-extractor/pull/94

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/StatusExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/StatusExtractor.swift
@@ -57,9 +57,6 @@ struct StatusExtractor: MarkupWalker, ValueExtractor {
             if let result = StatusExtractor.datesForString(String(statusMatch.details ?? ""), processingDate: extractionDate) {
                 start = result.start
                 end = result.end
-                if let warning = result.reviewEndedWarning {
-                    issues.reportIssue(warning, source: source)
-                }
             } else {
                 issues.reportIssue(.missingOrInvalidReviewDates, source: source)
             }
@@ -106,7 +103,7 @@ struct StatusExtractor: MarkupWalker, ValueExtractor {
     // For testing, a different processing date can be provided
     // VALIDATION ENHANCEMENT: A date range like (Apr 29 - May 3) will parse incorrectly by finding May and thinking both dates are in May
     // VALIDATION ENHANCEMENT: Something like (4 - 13 April 2022) will parse correctly. Should probably validate to the expected format
-    static func datesForString(_ string: String, processingDate: Date) -> (start: String, end: String, reviewEndedWarning: Proposal.Issue?)? {
+    static func datesForString(_ string: String, processingDate: Date) -> (start: String, end: String)? {
         
         // used in two case blocks; hoisting up here for reuse
         let integerMatcher = /\d+/
@@ -182,14 +179,10 @@ struct StatusExtractor: MarkupWalker, ValueExtractor {
 
         // Note this is not an error, it would be added as a warning.
         // VALIDATION ENHANCEMENT: Add (x) days before showing this.
-        var reviewEndedWarning: Proposal.Issue?
-        if processingDate > wrappedEndDate {
-            reviewEndedWarning = .reviewEnded(on: wrappedEndDate)
-        }
         
         // Specify explicit GMT time zone and 'en_US_POSIX' locale
         let dateFormatStyle = Date.ISO8601FormatStyle(timeZone: TimeZone.gmt).locale(Locale.en_US_POSIX)
-        return (startDate.formatted(dateFormatStyle), wrappedEndDate.formatted(dateFormatStyle), reviewEndedWarning)
+        return (startDate.formatted(dateFormatStyle), wrappedEndDate.formatted(dateFormatStyle))
     }
 }
 

--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/StatusExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/StatusExtractor.swift
@@ -176,9 +176,6 @@ struct StatusExtractor: MarkupWalker, ValueExtractor {
         if wrappedEndDate < startDate {
             wrappedEndDate = formatter.date(from: "\(endMonth) \(endDay) \(presentYear + 1)")!
         }
-
-        // Note this is not an error, it would be added as a warning.
-        // VALIDATION ENHANCEMENT: Add (x) days before showing this.
         
         // Specify explicit GMT time zone and 'en_US_POSIX' locale
         let dateFormatStyle = Date.ISO8601FormatStyle(timeZone: TimeZone.gmt).locale(Locale.en_US_POSIX)

--- a/Sources/EvolutionMetadataExtraction/Utilities/ValidationIssues.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/ValidationIssues.swift
@@ -211,16 +211,4 @@ extension Proposal.Issue {
         code: 112,
         message: "Discussion link doesn't refer to a Swift forum thread. Discussion removed."
     )
-
-    // VALIDATION ENHANCEMENTS: Consider not including the date in the review message, or not including time components.
-    // Comparing results currently breaks if recorded test values and actual values are generated in different time zones.
-    // Using GMT with generated legacy tool results to avoid for the present
-    static func reviewEnded(on endDate: Date) -> Proposal.Issue {
-        var calender = Calendar(identifier: .gregorian)
-        calender.timeZone = TimeZone.gmt
-        return Proposal.Issue(
-            kind: .warning,
-            message: "Review ended on \(calender.startOfDay(for: endDate))."
-        )
-    }
 }

--- a/Tests/ExtractionTests/Resources/AllProposals.evosnapshot/expected-results.json
+++ b/Tests/ExtractionTests/Resources/AllProposals.evosnapshot/expected-results.json
@@ -1,6 +1,6 @@
 {
   "commit" : "99d43502653b6fd3f521066c8a1971bce6a99bac",
-  "creationDate" : "2026-02-12T19:51:39Z",
+  "creationDate" : "2026-02-13T16:13:10Z",
   "implementationVersions" : [
     "2.2", "3.0", "3.0.1", "3.1", "4.0", "4.1", "4.2", "5.0", "5.1", "5.2",
     "5.3", "5.4", "5.5", "5.5.2", "5.6", "5.7", "5.8", "5.9", "5.9.2", "5.10",
@@ -20855,15 +20855,7 @@
         "state" : "activeReview"
       },
       "summary" : "An associated type defines a generic type in a protocol. You use them to help define the protocol's requirements. This Queue has two associated types, Element and Allocator:",
-      "title" : "Suppressed Default Conformances on Associated Types With Defaults",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2026-01-25 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Suppressed Default Conformances on Associated Types With Defaults"
     },
     {
       "authors" : [
@@ -21025,15 +21017,7 @@
         "state" : "activeReview"
       },
       "summary" : "Borrowing accessors — introduced with the new keywords `borrow` and `mutate` — allow implementing computed properties and subscripts using *borrowing semantics*.  These augment the existing `get`, `set`, `yielding borrow`, and `yielding mutate` accessors to complete the design described in the “Prospective Vision for Accessors”: https:\/\/forums.swift.org\/t\/prospective-vision-accessors\/76707",
-      "title" : "Borrow and Mutate Accessors",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2026-02-09 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Borrow and Mutate Accessors"
     },
     {
       "authors" : [
@@ -21075,15 +21059,7 @@
         "state" : "activeReview"
       },
       "summary" : "We add support for using trailing closures following array types in expressions.",
-      "title" : "Array expression trailing closures",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2026-02-12 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Array expression trailing closures"
     },
     {
       "authors" : [

--- a/Tests/ExtractionTests/Resources/Malformed.evosnapshot/expected-results.json
+++ b/Tests/ExtractionTests/Resources/Malformed.evosnapshot/expected-results.json
@@ -925,15 +925,7 @@
         "state" : "activeReview"
       },
       "summary" : "Introduce a new operator an \"Optional Value Setter\". If the optional is set via this operator then the new value is only set if there isn't an already existing value.",
-      "title" : "Optional Value Setter `??=`",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2024-01-05 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Optional Value Setter `??=`"
     },
     {
       "authors" : [
@@ -968,14 +960,6 @@
         {
           "id" : "SR-1275",
           "link" : "https:\/\/bugs.swift.org\/browse\/SR-1275"
-        }
-      ],
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2024-01-31 00:00:00 +0000.",
-          "suggestion" : ""
         }
       ]
     },

--- a/Tests/ExtractionTests/Resources/SameCommit.evosnapshot/expected-results.json
+++ b/Tests/ExtractionTests/Resources/SameCommit.evosnapshot/expected-results.json
@@ -19135,15 +19135,7 @@
         "state" : "activeReview"
       },
       "summary" : "This proposal introduces a new compiler setting for inferring `@MainActor` isolation by default within the module to mitigate false-positive data-race safety errors in sequential code.",
-      "title" : "Control default actor isolation inference",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-07-15 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Control default actor isolation inference"
     },
     {
       "authors" : [
@@ -19681,15 +19673,7 @@
         "state" : "activeReview"
       },
       "summary" : "[SE-0466: Control default actor isolation inference](\/proposals\/0466-control-default-actor-isolation.md) introduced the ability to specify default actor isolation on a per-module basis. This proposal introduces a new typealias for specifying default actor isolation in individual source files within a module. This allows specific files to opt out of main actor isolation within a main-actor-by-default module, and opt into main actor isolation within a nonisolated-by-default module.",
-      "title" : "Default actor isolation typealias",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-05-05 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Default actor isolation typealias"
     },
     {
       "authors" : [
@@ -19747,15 +19731,7 @@
         "state" : "activeReview"
       },
       "summary" : "Swift key paths can be written to properties and subscripts. This proposal extends key path usage to include references to method members, such as instance and type methods, and initializers.",
-      "title" : "Method and Initializer Key Paths",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-05-05 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Method and Initializer Key Paths"
     },
     {
       "authors" : [
@@ -20285,14 +20261,6 @@
           "id" : "SR-5714",
           "link" : "https:\/\/github.com\/swiftlang\/swift-package-manager\/issues\/5714"
         }
-      ],
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-09-18 00:00:00 +0000.",
-          "suggestion" : ""
-        }
       ]
     },
     {
@@ -20537,15 +20505,7 @@
         "state" : "activeReview"
       },
       "summary" : "Implementing a C function in Swift eases integration of Swift and C code. This proposal introduces `@c` to mark Swift functions as callable from C, and enums as representable in C. It provides the same behavior under the `@objc` attribute for Objective-C compatible global functions.",
-      "title" : "C compatible functions and enums",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-10-09 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "C compatible functions and enums"
     },
     {
       "authors" : [

--- a/Tests/ExtractionTests/Resources/SameCommit.evosnapshot/previous-results.json
+++ b/Tests/ExtractionTests/Resources/SameCommit.evosnapshot/previous-results.json
@@ -19135,15 +19135,7 @@
         "state" : "activeReview"
       },
       "summary" : "This proposal introduces a new compiler setting for inferring `@MainActor` isolation by default within the module to mitigate false-positive data-race safety errors in sequential code.",
-      "title" : "Control default actor isolation inference",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-07-15 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Control default actor isolation inference"
     },
     {
       "authors" : [
@@ -19681,15 +19673,7 @@
         "state" : "activeReview"
       },
       "summary" : "[SE-0466: Control default actor isolation inference](\/proposals\/0466-control-default-actor-isolation.md) introduced the ability to specify default actor isolation on a per-module basis. This proposal introduces a new typealias for specifying default actor isolation in individual source files within a module. This allows specific files to opt out of main actor isolation within a main-actor-by-default module, and opt into main actor isolation within a nonisolated-by-default module.",
-      "title" : "Default actor isolation typealias",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-05-05 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Default actor isolation typealias"
     },
     {
       "authors" : [
@@ -19747,15 +19731,7 @@
         "state" : "activeReview"
       },
       "summary" : "Swift key paths can be written to properties and subscripts. This proposal extends key path usage to include references to method members, such as instance and type methods, and initializers.",
-      "title" : "Method and Initializer Key Paths",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-05-05 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Method and Initializer Key Paths"
     },
     {
       "authors" : [
@@ -20285,14 +20261,6 @@
           "id" : "SR-5714",
           "link" : "https:\/\/github.com\/swiftlang\/swift-package-manager\/issues\/5714"
         }
-      ],
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-09-18 00:00:00 +0000.",
-          "suggestion" : ""
-        }
       ]
     },
     {
@@ -20537,15 +20505,7 @@
         "state" : "activeReview"
       },
       "summary" : "Implementing a C function in Swift eases integration of Swift and C code. This proposal introduces `@c` to mark Swift functions as callable from C, and enums as representable in C. It provides the same behavior under the `@objc` attribute for Objective-C compatible global functions.",
-      "title" : "C compatible functions and enums",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-10-09 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "C compatible functions and enums"
     },
     {
       "authors" : [

--- a/Tests/ExtractionTests/Resources/WithUpdates-BaseCommit.evosnapshot/expected-results.json
+++ b/Tests/ExtractionTests/Resources/WithUpdates-BaseCommit.evosnapshot/expected-results.json
@@ -19135,15 +19135,7 @@
         "state" : "activeReview"
       },
       "summary" : "This proposal introduces a new compiler setting for inferring `@MainActor` isolation by default within the module to mitigate false-positive data-race safety errors in sequential code.",
-      "title" : "Control default actor isolation inference",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-07-15 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Control default actor isolation inference"
     },
     {
       "authors" : [
@@ -19681,15 +19673,7 @@
         "state" : "activeReview"
       },
       "summary" : "[SE-0466: Control default actor isolation inference](\/proposals\/0466-control-default-actor-isolation.md) introduced the ability to specify default actor isolation on a per-module basis. This proposal introduces a new typealias for specifying default actor isolation in individual source files within a module. This allows specific files to opt out of main actor isolation within a main-actor-by-default module, and opt into main actor isolation within a nonisolated-by-default module.",
-      "title" : "Default actor isolation typealias",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-05-05 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Default actor isolation typealias"
     },
     {
       "authors" : [
@@ -19747,15 +19731,7 @@
         "state" : "activeReview"
       },
       "summary" : "Swift key paths can be written to properties and subscripts. This proposal extends key path usage to include references to method members, such as instance and type methods, and initializers.",
-      "title" : "Method and Initializer Key Paths",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-05-05 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Method and Initializer Key Paths"
     },
     {
       "authors" : [
@@ -20427,15 +20403,7 @@
         "state" : "activeReview"
       },
       "summary" : "This is a targeted proposal to introduce support for asynchronous calls within `defer` statements. Such calls must be marked with `await` as any other asynchronous call would be, and `defer` statements which do asynchronous work will be implicitly awaited at any relevant scope exit point.",
-      "title" : "Support `async` calls in `defer` bodies",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-10-06 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Support `async` calls in `defer` bodies"
     },
     {
       "authors" : [
@@ -20501,15 +20469,7 @@
         "state" : "activeReview"
       },
       "summary" : "We propose new `isIdentical(to:)` instance methods to concrete types for quickly determining if two instances must be equal by-value.",
-      "title" : "Add `isIdentical(to:)` Methods for Quick Comparisons to Concrete Types",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-10-06 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Add `isIdentical(to:)` Methods for Quick Comparisons to Concrete Types"
     },
     {
       "authors" : [

--- a/Tests/ExtractionTests/Resources/WithUpdates.evosnapshot/expected-results.json
+++ b/Tests/ExtractionTests/Resources/WithUpdates.evosnapshot/expected-results.json
@@ -19135,15 +19135,7 @@
         "state" : "activeReview"
       },
       "summary" : "This proposal introduces a new compiler setting for inferring `@MainActor` isolation by default within the module to mitigate false-positive data-race safety errors in sequential code.",
-      "title" : "Control default actor isolation inference",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-07-15 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Control default actor isolation inference"
     },
     {
       "authors" : [
@@ -19681,15 +19673,7 @@
         "state" : "activeReview"
       },
       "summary" : "[SE-0466: Control default actor isolation inference](\/proposals\/0466-control-default-actor-isolation.md) introduced the ability to specify default actor isolation on a per-module basis. This proposal introduces a new typealias for specifying default actor isolation in individual source files within a module. This allows specific files to opt out of main actor isolation within a main-actor-by-default module, and opt into main actor isolation within a nonisolated-by-default module.",
-      "title" : "Default actor isolation typealias",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-05-05 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Default actor isolation typealias"
     },
     {
       "authors" : [
@@ -19747,15 +19731,7 @@
         "state" : "activeReview"
       },
       "summary" : "Swift key paths can be written to properties and subscripts. This proposal extends key path usage to include references to method members, such as instance and type methods, and initializers.",
-      "title" : "Method and Initializer Key Paths",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-05-05 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Method and Initializer Key Paths"
     },
     {
       "authors" : [
@@ -20285,14 +20261,6 @@
           "id" : "SR-5714",
           "link" : "https:\/\/github.com\/swiftlang\/swift-package-manager\/issues\/5714"
         }
-      ],
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-09-18 00:00:00 +0000.",
-          "suggestion" : ""
-        }
       ]
     },
     {
@@ -20537,15 +20505,7 @@
         "state" : "activeReview"
       },
       "summary" : "Implementing a C function in Swift eases integration of Swift and C code. This proposal introduces `@c` to mark Swift functions as callable from C, and enums as representable in C. It provides the same behavior under the `@objc` attribute for Objective-C compatible global functions.",
-      "title" : "C compatible functions and enums",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-10-09 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "C compatible functions and enums"
     },
     {
       "authors" : [

--- a/Tests/ExtractionTests/Resources/WithUpdates.evosnapshot/previous-results.json
+++ b/Tests/ExtractionTests/Resources/WithUpdates.evosnapshot/previous-results.json
@@ -19135,15 +19135,7 @@
         "state" : "activeReview"
       },
       "summary" : "This proposal introduces a new compiler setting for inferring `@MainActor` isolation by default within the module to mitigate false-positive data-race safety errors in sequential code.",
-      "title" : "Control default actor isolation inference",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-07-15 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Control default actor isolation inference"
     },
     {
       "authors" : [
@@ -19681,15 +19673,7 @@
         "state" : "activeReview"
       },
       "summary" : "[SE-0466: Control default actor isolation inference](\/proposals\/0466-control-default-actor-isolation.md) introduced the ability to specify default actor isolation on a per-module basis. This proposal introduces a new typealias for specifying default actor isolation in individual source files within a module. This allows specific files to opt out of main actor isolation within a main-actor-by-default module, and opt into main actor isolation within a nonisolated-by-default module.",
-      "title" : "Default actor isolation typealias",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-05-05 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Default actor isolation typealias"
     },
     {
       "authors" : [
@@ -19747,15 +19731,7 @@
         "state" : "activeReview"
       },
       "summary" : "Swift key paths can be written to properties and subscripts. This proposal extends key path usage to include references to method members, such as instance and type methods, and initializers.",
-      "title" : "Method and Initializer Key Paths",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-05-05 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Method and Initializer Key Paths"
     },
     {
       "authors" : [
@@ -20427,15 +20403,7 @@
         "state" : "activeReview"
       },
       "summary" : "This is a targeted proposal to introduce support for asynchronous calls within `defer` statements. Such calls must be marked with `await` as any other asynchronous call would be, and `defer` statements which do asynchronous work will be implicitly awaited at any relevant scope exit point.",
-      "title" : "Support `async` calls in `defer` bodies",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-10-06 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Support `async` calls in `defer` bodies"
     },
     {
       "authors" : [
@@ -20501,15 +20469,7 @@
         "state" : "activeReview"
       },
       "summary" : "We propose new `isIdentical(to:)` instance methods to concrete types for quickly determining if two instances must be equal by-value.",
-      "title" : "Add `isIdentical(to:)` Methods for Quick Comparisons to Concrete Types",
-      "warnings" : [
-        {
-          "code" : 0,
-          "kind" : "warning",
-          "message" : "Review ended on 2025-10-06 00:00:00 +0000.",
-          "suggestion" : ""
-        }
-      ]
+      "title" : "Add `isIdentical(to:)` Methods for Quick Comparisons to Concrete Types"
     },
     {
       "authors" : [


### PR DESCRIPTION
This pull request removes the warning that is currently reported when a proposal has a past-due review period.

The rationale for removing the warning is detailed in Issue #73.

The main reasons are:
  - The warning is not used by the evolution dashboard or any known clients of the json file
  - The warning depends on when the extractor is run and so can easily be incorrect as time passes
  - The same set of inputs can generate different output depending on when run, complicating testing
  - If desired, a client can determine past-due proposals by further processing of the generated metadata

This PR also:
- Update tests and changelog
- Resolves #73