### PR TITLE
Temporarily treat new Expired status as Rejected

### DIFF
--- a/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/StatusExtractor.swift
+++ b/Sources/EvolutionMetadataExtraction/Extractors/FieldExtractors/StatusExtractor.swift
@@ -204,6 +204,8 @@ extension Proposal.Status {
             case "Accepted with modifications".lowercased(): self = .accepted
             case "Partially implemented".lowercased(): self = .implemented(version: version)
             case "Implemented with Modifications".lowercased(): self = .implemented(version: version)
+            // TEMPORARY: Treat 'Expired' as Rejected until addition is confirmed and dashboard is updated
+            case "Expired".lowercased(): self = .rejected
             default: return nil
         }
     }


### PR DESCRIPTION
The Language Steering Group set the status of proposal SE-0246 to 'Expired'. In the past, proposals that were accepted but not implemented within a year (or so) were given the status 'Rejected'.

This change allows 'Expired' as an expected status, so it does not cause a validation error, but until the evolution dashboard is updated for the newly added 'Expired' status, the 'Expired' status is extracted as the previously correct 'Rejected' status.