### PR TITLE
Make pull file patch property optional

### DIFF
--- a/Sources/EvolutionMetadataExtraction/Utilities/Networking.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/Networking.swift
@@ -78,8 +78,9 @@ struct GitHubPullFileItem: Codable {
     var blob_url: String
     var raw_url: String
     var contents_url: String
-    var patch: String
-    
+    var patch: String?
+    var previous_filename: String?
+
     var isProposalFile: Bool {
         status != "removed" &&
         filename.hasPrefix("proposals/") &&


### PR DESCRIPTION
Make `GitHubPullFileItem` `patch` property optional. Binary files such as images do not have a patch field, so parsing was causing an exception.

Add missing optional `previous_filename` property to `GitHubPullFileItem`.