### PR TITLE
Update manifest to use latest swift-markdown

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .executable(name: "swift-evolution-metadata-extractor", targets: ["swift-evolution-metadata-extractor"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-markdown", exact: "0.7.1"),
+        .package(url: "https://github.com/swiftlang/swift-markdown", from: "0.8.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
     ],
     targets: [


### PR DESCRIPTION
Update manifest to use swift-markdown versions from 0.8.0 (the current version).

Resolves #80