### PR TITLE
Fix hyperlink syntax in error messages

### DIFF
--- a/Sources/EvolutionMetadataExtraction/Utilities/ValidationIssues.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/ValidationIssues.swift
@@ -57,7 +57,7 @@ extension Proposal.Issue {
     static let missingProposalIDLink = Proposal.Issue(
         kind: .error,
         code: 31,
-        message: "Missing proposal ID link (SE-NNNN)[NNNN-filename.md]."
+        message: "Missing proposal ID link [SE-NNNN](NNNN-filename.md)."
     )
 
     static let proposalIDWrongDigitCount = Proposal.Issue(
@@ -75,7 +75,7 @@ extension Proposal.Issue {
     static let invalidProposalIDLink = Proposal.Issue(
         kind: .error,
         code: 34,
-        message: "Proposal ID link must be a relative link (SE-NNNN)[NNNN-filename.md]."
+        message: "Proposal ID link must be a relative link [SE-NNNN](NNNN-filename.md)."
     )
 
     static let reservedProposalID = Proposal.Issue(

--- a/Tests/ExtractionTests/Resources/Malformed.evosnapshot/expected-results.json
+++ b/Tests/ExtractionTests/Resources/Malformed.evosnapshot/expected-results.json
@@ -69,7 +69,7 @@
         {
           "code" : 31,
           "kind" : "error",
-          "message" : "Missing proposal ID link (SE-NNNN)[NNNN-filename.md].",
+          "message" : "Missing proposal ID link [SE-NNNN](NNNN-filename.md).",
           "suggestion" : ""
         }
       ],
@@ -264,7 +264,7 @@
         {
           "code" : 34,
           "kind" : "error",
-          "message" : "Proposal ID link must be a relative link (SE-NNNN)[NNNN-filename.md].",
+          "message" : "Proposal ID link must be a relative link [SE-NNNN](NNNN-filename.md).",
           "suggestion" : ""
         }
       ],
@@ -393,7 +393,7 @@
         {
           "code" : 34,
           "kind" : "error",
-          "message" : "Proposal ID link must be a relative link (SE-NNNN)[NNNN-filename.md].",
+          "message" : "Proposal ID link must be a relative link [SE-NNNN](NNNN-filename.md).",
           "suggestion" : ""
         }
       ],
@@ -1182,7 +1182,7 @@
         {
           "code" : 31,
           "kind" : "error",
-          "message" : "Missing proposal ID link (SE-NNNN)[NNNN-filename.md].",
+          "message" : "Missing proposal ID link [SE-NNNN](NNNN-filename.md).",
           "suggestion" : ""
         },
         {


### PR DESCRIPTION
Two of the error messages have their markdown hyperlink syntax reversed.