### PR TITLE
Remove percent encoding from pull item URL strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Add new items at the end of the relevant section under **Unreleased**.
 
 ### Fixes
 
+- Fix proposals in pull requests ignoring validation exemptions ([#131])
 - Fix incorrect error message ([#119])
 
 ## [1.1.0] - 2026-07-10
@@ -122,3 +123,4 @@ This changelog's format is based on [Keep a Changelog](https://keepachangelog.co
 [#117]: https://github.com/swiftlang/swift-evolution-metadata-extractor/pull/117
 [#119]: https://github.com/swiftlang/swift-evolution-metadata-extractor/pull/119
 [#121]: https://github.com/swiftlang/swift-evolution-metadata-extractor/pull/121
+[#131]: https://github.com/swiftlang/swift-evolution-metadata-extractor/pull/131

--- a/Sources/EvolutionMetadataExtraction/Utilities/Networking.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/Networking.swift
@@ -88,7 +88,9 @@ struct GitHubPullFileItem: Codable {
     }
 
     func proposalSpec(project: Project, sortIndex: Int) ->  ProposalSpec {
-        ProposalSpec(project: project, url: URL(string: raw_url)!, sha: sha, sortIndex: sortIndex)
+        // The url values contain percent-encoded slashes (%2F) in directory paths
+        // This prevented proper extraction of the proposal number from the proposal filename
+        return ProposalSpec(project: project, url: URL(string: raw_url.removingPercentEncoding!)!, sha: sha, sortIndex: sortIndex)
     }
 
 }

--- a/Sources/EvolutionMetadataExtraction/Utilities/Networking.swift
+++ b/Sources/EvolutionMetadataExtraction/Utilities/Networking.swift
@@ -90,7 +90,7 @@ struct GitHubPullFileItem: Codable {
     func proposalSpec(project: Project, sortIndex: Int) ->  ProposalSpec {
         // The url values contain percent-encoded slashes (%2F) in directory paths
         // This prevented proper extraction of the proposal number from the proposal filename
-        return ProposalSpec(project: project, url: URL(string: raw_url.removingPercentEncoding!)!, sha: sha, sortIndex: sortIndex)
+        ProposalSpec(project: project, url: URL(string: raw_url.removingPercentEncoding!)!, sha: sha, sortIndex: sortIndex)
     }
 
 }


### PR DESCRIPTION
- Ensures proposal spec can extract the proposal number from filename
- Fixes #130